### PR TITLE
🔧 Fix trailing comma in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,5 @@
   ],
   "lockFileMaintenance": {
     "enabled": false
-  },
+  }
 }


### PR DESCRIPTION
## Summary

Fixes a trailing comma in `renovate.json` that makes the file technically invalid JSON (Renovate parses it leniently, but strict JSON parsers reject it).

No behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)